### PR TITLE
Add how to include Inter UI using a <link>... tag

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -79,10 +79,13 @@
       <p>
         You're free to bundle copies of Inter UI with your software, even if it's
         commercial and you charge money for your software. Inter UI can also be used
-        on the web by either hosting the font files yourself or by including this CSS:
+        on the web by either hosting the font files yourself or by including it in your code. 
+        Copy this into the <head> of your HTML document:
       </p>
+      <code><link href="https://rsms.me/inter/inter-ui.css" rel="stylesheet"></code>
+      <p>Or include this in your CSS:</p>
       <code>@import url('https://rsms.me/inter/inter-ui.css');</code>
-      <p>Use the following CSS rules to specify the Inter UI family:</p>
+      <p>Use the following CSS rule to specify the Inter UI family:</p>
       <code>font-family: 'Inter UI', sans-serif;</code>
     </div></div>
 


### PR DESCRIPTION
Added that Inter UI can be included using a <link> tag as well, next to the @import CSS rule. This way is almost always preferred, because - as opposed to using @include - it doesn't block further loading.

More information can be found in this blog post (not mine): http://www.stevesouders.com/blog/2009/04/09/dont-use-import/