### PR TITLE
Add missing backslash in init.sh

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -273,7 +273,7 @@ else
   LINK=false
   if [[ ! -f "$DEPS_DIR/ttfautohint-${AUTOHINT_VERSION}" ]]; then
     fetch \
-      https://download.savannah.gnu.org/releases/freetype/ttfautohint-${AUTOHINT_VERSION}-tty-osx.tar.gz
+      https://download.savannah.gnu.org/releases/freetype/ttfautohint-${AUTOHINT_VERSION}-tty-osx.tar.gz \
       "$DEPS_DIR/ttfautohint.tar.gz"
     tar -C "$DEPS_DIR" -xzf "$DEPS_DIR/ttfautohint.tar.gz"
     rm "$DEPS_DIR/ttfautohint.tar.gz"


### PR DESCRIPTION
The script was trying to execute `curl '-#' -o "" -L "https://download.savannah.gnu.org/releases/freetype/ttfautohint-1.8.2-tty-osx.tar.gz"`, causing the script to halt due to an error:

```raw
Fetching https://download.savannah.gnu.org/releases/freetype/ttfautohint-1.8.2-tty-osx.tar.gz
Warning: Remote filename has no length!

curl: (23) Failed writing body (0 != 16139)
```