### PR TITLE
Serve symlink patch: fix error exception to serve lab if symlink exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ _*.ignore
 *~
 .DS_Store
 nohup.out
+.vscode/
 
 build
 /_*

--- a/docs/lab/serve.py
+++ b/docs/lab/serve.py
@@ -26,7 +26,7 @@ class HTTPServer(http.server.HTTPServer):
 labdir = abspath(dirname(__file__))
 try:
   os.symlink('../../build/fonts', pjoin(labdir, 'fonts'))
-except FileExistsError:
+except OSError:
   pass
 
 addr = ("localhost", 3003)


### PR DESCRIPTION
The update to `serve.py` allowed me to serve the lab on my first try, but failed on a subsequent try with:

```
(venv) ▶ python docs/lab/serve.py      
------------------------------------------
Traceback (most recent call last):
  File "docs/lab/serve.py", line 29, in <module>
    except FileExistsError:
NameError: name 'FileExistsError' is not defined
```

I believe this is because `FileExistsError` isn't a built-in exception. If this is changed to `OSError`, things work as expected.

I don't know if there is a better way to do this, but here's the OSError doc if helpful:
https://docs.python.org/3/library/exceptions.html#OSError

I also had to create a VSCode setting to avoid auto-formatting in my workspace. If you would prefer to not have this in the `.gitignore` file, I can edit this PR to exclude that change. However, I'll also need to find how to properly do that for all future commits, as well, so I might want to PR that change separately if it's alright to include.

