### PR TITLE
add 'Version ' to nameID 5 version string, per MS OT spec

### DIFF
--- a/misc/fontbuild
+++ b/misc/fontbuild
@@ -228,7 +228,7 @@ def updateFontVersion(font, dummy=False):
   font.info.woffMajorVersion = versionMajor
   font.info.woffMinorVersion = versionMinor
   font.info.year = now.year
-  font.info.openTypeNameVersion = "%d.%03d;git-%s" % (
+  font.info.openTypeNameVersion = "Version %d.%03d;git-%s" % (
     versionMajor, versionMinor, buildtag)
   font.info.openTypeNameUniqueID = "%s %s:%d:%s" % (
     font.info.familyName, font.info.styleName, now.year, buildtag)


### PR DESCRIPTION
Inter's nameID 5 formatting was been improved by https://github.com/rsms/inter/commit/20aaab681df22c8251fbc1bb68fbd38a1b858b32, but still fails FontBakery check 055:

<details>
<summary>🔥<b>FAIL:</b> Version format is correct in 'name' table?</summary>

* [com.google.fonts/check/055](https://github.com/googlefonts/fontbakery/search?q=com.google.fonts/check/055)
* 🔥**FAIL** The NameID.VERSION_STRING (nameID=5) value must follow the pattern "Version X.Y" with X.Y between 1.000 and 9.999. Current version string is: "3.4;6e0206421" [code: bad-version-strings]

</details>

According to the [Microsoft OpenType spec for nameID 5](https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-ids):

> Version string. Should begin with the syntax “Version <number>.<number>” (upper case, lower case, or mixed, with a space between “Version” and the number). 

This PR is a small change that makes that happen, allowing Inter to successfully pass check 055.