### PR TITLE
Give precedence to local() in src list

### DIFF
--- a/misc/dist/inter.css
+++ b/misc/dist/inter.css
@@ -2,14 +2,16 @@
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 100;
-  src: url("Inter-Thin-BETA.woff2") format("woff2"),
+  src: local("Inter-Thin-BETA"),
+       url("Inter-Thin-BETA.woff2") format("woff2"),
        url("Inter-Thin-BETA.woff") format("woff");
 }
 @font-face {
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 100;
-  src: url("Inter-ThinItalic-BETA.woff2") format("woff2"),
+  src: local("Inter-ThinItalic-BETA"),
+       url("Inter-ThinItalic-BETA.woff2") format("woff2"),
        url("Inter-ThinItalic-BETA.woff") format("woff");
 }
 
@@ -17,14 +19,16 @@
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 200;
-  src: url("Inter-ExtraLight-BETA.woff2") format("woff2"),
+  src: local("Inter-ExtraLight-BETA"),
+       url("Inter-ExtraLight-BETA.woff2") format("woff2"),
        url("Inter-ExtraLight-BETA.woff") format("woff");
 }
 @font-face {
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 200;
-  src: url("Inter-ExtraLightItalic-BETA.woff2") format("woff2"),
+  src: local("Inter-ExtraLightItalic-BETA"),
+       url("Inter-ExtraLightItalic-BETA.woff2") format("woff2"),
        url("Inter-ExtraLightItalic-BETA.woff") format("woff");
 }
 
@@ -32,14 +36,16 @@
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 300;
-  src: url("Inter-Light-BETA.woff2") format("woff2"),
+  src: local("Inter-Light-BETA"),
+       url("Inter-Light-BETA.woff2") format("woff2"),
        url("Inter-Light-BETA.woff") format("woff");
 }
 @font-face {
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 300;
-  src: url("Inter-LightItalic-BETA.woff2") format("woff2"),
+  src: local("Inter-LightItalic-BETA"),
+       url("Inter-LightItalic-BETA.woff2") format("woff2"),
        url("Inter-LightItalic-BETA.woff") format("woff");
 }
 
@@ -47,14 +53,16 @@
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 400;
-  src: url("Inter-Regular.woff2") format("woff2"),
+  src: local("Inter-Regular"),
+       url("Inter-Regular.woff2") format("woff2"),
        url("Inter-Regular.woff") format("woff");
 }
 @font-face {
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 400;
-  src: url("Inter-Italic.woff2") format("woff2"),
+  src: local("Inter-Italic"),
+       url("Inter-Italic.woff2") format("woff2"),
        url("Inter-Italic.woff") format("woff");
 }
 
@@ -62,14 +70,16 @@
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 500;
-  src: url("Inter-Medium.woff2") format("woff2"),
+  src: local("Inter-Medium"),
+       url("Inter-Medium.woff2") format("woff2"),
        url("Inter-Medium.woff") format("woff");
 }
 @font-face {
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 500;
-  src: url("Inter-MediumItalic.woff2") format("woff2"),
+  src: local("Inter-MediumItalic"),
+       url("Inter-MediumItalic.woff2") format("woff2"),
        url("Inter-MediumItalic.woff") format("woff");
 }
 
@@ -77,14 +87,16 @@
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 600;
-  src: url("Inter-SemiBold.woff2") format("woff2"),
+  src: local("Inter-SemiBold"),
+       url("Inter-SemiBold.woff2") format("woff2"),
        url("Inter-SemiBold.woff") format("woff");
 }
 @font-face {
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 600;
-  src: url("Inter-SemiBoldItalic.woff2") format("woff2"),
+  src: local("Inter-SemiBoldItalic"),
+       url("Inter-SemiBoldItalic.woff2") format("woff2"),
        url("Inter-SemiBoldItalic.woff") format("woff");
 }
 
@@ -92,14 +104,16 @@
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 700;
-  src: url("Inter-Bold.woff2") format("woff2"),
+  src: local("Inter-Bold"),
+       url("Inter-Bold.woff2") format("woff2"),
        url("Inter-Bold.woff") format("woff");
 }
 @font-face {
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 700;
-  src: url("Inter-BoldItalic.woff2") format("woff2"),
+  src: local("Inter-BoldItalic"),
+       url("Inter-BoldItalic.woff2") format("woff2"),
        url("Inter-BoldItalic.woff") format("woff");
 }
 
@@ -107,14 +121,16 @@
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 800;
-  src: url("Inter-ExtraBold.woff2") format("woff2"),
+  src: local("Inter-ExtraBold"),
+       url("Inter-ExtraBold.woff2") format("woff2"),
        url("Inter-ExtraBold.woff") format("woff");
 }
 @font-face {
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 800;
-  src: url("Inter-ExtraBoldItalic.woff2") format("woff2"),
+  src: local("Inter-ExtraBoldItalic"),
+       url("Inter-ExtraBoldItalic.woff2") format("woff2"),
        url("Inter-ExtraBoldItalic.woff") format("woff");
 }
 
@@ -122,14 +138,16 @@
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 900;
-  src: url("Inter-Black.woff2") format("woff2"),
+  src: local("Inter-Black"),
+       url("Inter-Black.woff2") format("woff2"),
        url("Inter-Black.woff") format("woff");
 }
 @font-face {
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 900;
-  src: url("Inter-BlackItalic.woff2") format("woff2"),
+  src: local("Inter-BlackItalic"),
+       url("Inter-BlackItalic.woff2") format("woff2"),
        url("Inter-BlackItalic.woff") format("woff");
 }
 
@@ -147,14 +165,16 @@ Usage:
   font-weight: 100 900;
   font-style: normal;
   font-named-instance: 'Regular';
-  src: url("Inter-upright.var.woff2") format("woff2");
+  src: local("Inter-Regular"),
+       url("Inter-upright.var.woff2") format("woff2");
 }
 @font-face {
   font-family: 'Inter var';
   font-weight: 100 900;
   font-style: italic;
   font-named-instance: 'Italic';
-  src: url("Inter-italic.var.woff2") format("woff2");
+  src: local("Inter-Italic"),
+       url("Inter-italic.var.woff2") format("woff2");
 }
 
 


### PR DESCRIPTION
This is particularly useful for when Inter is packaged in a distributed app using something like Electron, CEF, etc.

From [Google's Web Font Optimization](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization#defining_a_font_family_with_font-face) (emphasis mine):

> Unless you're referencing one of the default system fonts, it is rare for the user to have it locally installed, especially on mobile devices, where it is effectively impossible to "install" additional fonts. You should **always start with a local() entry "just in case,"** and then provide a list of url() entries.
> ...
> Optimization Checklist
> - ...
> - Give precedence to local() in your src list: listing local('Font Name') first in your src list ensures that HTTP requests aren't made for fonts that are already installed.
> - ...

A couple of things I am unsure about:

1. Should we provide both `local("Inter Regular")` and `local("Inter-Regular")` variants?
2. Since a locally installed variable should have the same name (#144), how do we reference a local instance of `Inter var` without prevent a non-variable local install of `Inter-Regular` from being used for all weights?