### PR TITLE
Have two independent scrollable regions

### DIFF
--- a/docs/lab/index.html
+++ b/docs/lab/index.html
@@ -781,7 +781,7 @@ samples.set('Body text Russian', `Статья 1 Все люди рождают�
 
 Статья 2 Каждый человек должен обладать всеми правами и всеми свободами, провозглашенными настоящей Декларацией, без какого бы то ни было различия, как-то в отношении расы, цвета кожи, пола, языка, религии, политических или иных убеждений, национального или социального происхождения, имущественного, сословного или иного положения. Кроме того, не должно проводиться никакого различия на основе политического, правового или международного статуса страны или территории, к которой человек принадлежит, независимо от того, является ли эта территория независимой, подопечной, несамоуправляющейся или как-либо иначе ограниченной в своем суверенитете.
 
-Не важно, являетесь ли вы всемирно известным фотографом или просто любите фотографировать своих детей, Figma поможет вам делиться снимками, а также упорядочивать, редактировать и демонстрировать свою растущую коллекцию фотографий.
+Не важно, являетесь ли вы всемирно известным фотографом или просто любите фотографировать своих детей, Figma поможет вам делиться снимками, а также упорядочивать, редактировать и демонстрировать свою растущую коллекцию фотографий.
 
 ————
 
@@ -1770,21 +1770,21 @@ document.head.appendChild(fontCSS)
 
     </div>
 
-    <boxes>
-      <box contenteditable spellcheck="false" class="primaryFont "><span>Rectangle</span></box>
-      <box contenteditable spellcheck="false" class="primaryFont positive"><span>Rectangle</span></box>
-      <box contenteditable spellcheck="false" class="primaryFont positive tight"><span>Rectangle</span></box>
-      <box contenteditable spellcheck="false" class="primaryFont centered positive"><span>Rectangle</span></box>
-
-      <sep></sep>
-
-      <box contenteditable spellcheck="false" class="secondaryFont showOnlyWithSecondarySample"><span>Rectangle</span></box>
-      <box contenteditable spellcheck="false" class="secondaryFont positive showOnlyWithSecondarySample"><span>Rectangle</span></box>
-      <box contenteditable spellcheck="false" class="secondaryFont positive tight showOnlyWithSecondarySample"><span>Rectangle</span></box>
-      <box contenteditable spellcheck="false" class="secondaryFont centered positive showOnlyWithSecondarySample"><span>Rectangle</span></box>
-    </boxes>
-
     <div class="preview">
+      <boxes>
+        <box contenteditable spellcheck="false" class="primaryFont "><span>Rectangle</span></box>
+        <box contenteditable spellcheck="false" class="primaryFont positive"><span>Rectangle</span></box>
+        <box contenteditable spellcheck="false" class="primaryFont positive tight"><span>Rectangle</span></box>
+        <box contenteditable spellcheck="false" class="primaryFont centered positive"><span>Rectangle</span></box>
+
+        <sep></sep>
+
+        <box contenteditable spellcheck="false" class="secondaryFont showOnlyWithSecondarySample"><span>Rectangle</span></box>
+        <box contenteditable spellcheck="false" class="secondaryFont positive showOnlyWithSecondarySample"><span>Rectangle</span></box>
+        <box contenteditable spellcheck="false" class="secondaryFont positive tight showOnlyWithSecondarySample"><span>Rectangle</span></box>
+        <box contenteditable spellcheck="false" class="secondaryFont centered positive showOnlyWithSecondarySample"><span>Rectangle</span></box>
+      </boxes>
+
       <samples>
         <sample contenteditable spellcheck="false" class="primary inter"></sample>
         <sample contenteditable spellcheck="false" class="secondary"></sample>

--- a/docs/lab/lab.css
+++ b/docs/lab/lab.css
@@ -15,8 +15,14 @@
 }
 
 * { margin:0; padding:0; font-synthesis: none; }
-html { }
+html {
+  height: 100%;
+}
 body {
+  height: 100%;
+  display: flex;
+  flex-wrap: nowrap;
+  overflow: hidden;
   background-color: white;
   color:#111;
   font:11px serif;
@@ -91,10 +97,10 @@ select:focus {
 }
 
 .options {
-  width: 275px;
+  flex-grow: 0;
+  order: 2;
+  min-width: 275px;
   box-sizing:border-box;
-  position:fixed;
-  top:0; right:0; bottom:0;
   background:#f4f4f4;
   padding: 24px;
   user-select:none; -moz-user-select: none; -webkit-user-select:none;
@@ -234,7 +240,7 @@ select:focus {
 
 .preview {
   display:flex;
-  margin-right:275px; /*width of options sidebar*/
+  flex-grow: 1;
   overflow: auto;
 }
 

--- a/docs/lab/lab.css
+++ b/docs/lab/lab.css
@@ -240,6 +240,7 @@ select:focus {
 
 .preview {
   display:flex;
+  flex-direction: column;
   flex-grow: 1;
   overflow: auto;
 }


### PR DESCRIPTION
Currently, the page stacks the scrollbars on the right side, like this:
<img width="732" alt="Screenshot 2019-12-21 17 08 55" src="https://user-images.githubusercontent.com/5077225/71310664-f5cdb100-2416-11ea-935d-8d2087d9e355.png">

With some small tweaks, we can allow the scrollbars to be paired with their respective scrollable regions:
<img width="732" alt="Screenshot 2019-12-21 17 08 40" src="https://user-images.githubusercontent.com/5077225/71310665-f5cdb100-2416-11ea-97e3-19d61f9a7d35.png">
