### PR TITLE
Fix the Sponsor button on your website

### DIFF
--- a/docs/index.css
+++ b/docs/index.css
@@ -286,6 +286,7 @@ boxes.features grid .sample em {
 #sponsor-button span {
   display: flex;
   align-items: center;
+  white-space: nowrap;
 }
 #sponsor-button span::before {
   content: "♥";


### PR DESCRIPTION
On your website I saw the Sponsor button looks having a small problem that makes the text reflow to the next line.

![Screenshot_2021-03-02 Inter font family](https://user-images.githubusercontent.com/10364351/109532621-413c1e80-7af4-11eb-952e-7a5109d921c4.png)
Screenshot from Firefox v86

To fix that, I insert the `white-space` property into the button, then the button looks better, and I hope you can accept my fix.
Regards