### PR TITLE
Add Māori to supported languages

### DIFF
--- a/docs/_data/languages.yml
+++ b/docs/_data/languages.yml
@@ -93,6 +93,7 @@
   - Malagasy
   - Maltese
   - Manx
+  - Māori
   - Masai
   - Meru
   - Metaʼ


### PR DESCRIPTION
[Māori](https://en.wikipedia.org/wiki/M%C4%81ori_language) uses the Basic Latin block plus `āēīōū`, all of which are supported.