### PR TITLE
web: Remove arrows for number input on Firefox

### DIFF
--- a/docs/index.css
+++ b/docs/index.css
@@ -139,6 +139,9 @@ h1 {
     /*box-shadow: 0 2px 0 0 var(--red);*/
     background: rgba(0, 0, 0, 0.07);
   }
+  .dynmet-calc input[type=number] {
+    appearance: textfield;
+  }
   .dynmet-calc input[type=number]::-webkit-inner-spin-button,
   .dynmet-calc input[type=number]::-webkit-outer-spin-button {
     -webkit-appearance: none;


### PR DESCRIPTION
#### On Firefox v90:
![image](https://user-images.githubusercontent.com/44368997/122646697-21317900-d13e-11eb-91a8-3e47a48eedb4.png)

#### On Chrome v91:
![image](https://user-images.githubusercontent.com/44368997/122646719-4920dc80-d13e-11eb-98b8-e64dc27e2188.png)

The arrows obstruct the input and this PR thus removes them for Firefox.