### PR TITLE
Pump skia-pathops version to 0.7.1 for mac m1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cu2qu==1.6.7
 glyphsLib==5.3.2
 ufo2ft[pathops]==2.20.0
 defcon[lxml]==0.8.1
-skia-pathops==0.6.0.post2
+skia-pathops==0.7.1
 gftools==0.7.0
 
 # only used for DesignSpaceDocumentReader in fontbuild


### PR DESCRIPTION
I bump the skia-pathops to v0.7.1

The 0.6.0.post2 don't wheels well on a Macbook pro M1.

Skia-pathops v0.7.1 now ships with linux-aarch64 (arm64) wheels as well now!
https://pypi.org/project/skia-pathops/0.7.1/#files

I test it on Mac, it works for me. 
I have no linux computer to test it.

Best,