### PR TITLE
Feat/kerning number 4 and colon

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cu2qu==1.6.7
 glyphsLib==5.3.2
 ufo2ft[pathops]==2.20.0
 defcon[lxml]==0.8.1
-skia-pathops==0.6.0.post2
+skia-pathops==0.7.1
 gftools==0.7.0
 
 # only used for DesignSpaceDocumentReader in fontbuild


### PR DESCRIPTION
This is my first PR for the font itself.

I have added more space on the right in between the number four kern group and the colon kern group to balance well Black 4 shape.

Let me know if it is not the right way to contribute.

<img width="1234" alt="image" src="https://user-images.githubusercontent.com/197471/150658417-d2453c69-6a9e-40bc-9f1a-c2c44395a24e.png">

<img width="653" alt="image" src="https://user-images.githubusercontent.com/197471/150658650-7c077f8f-7a48-4147-866e-933f77a809c7.png">

