### PR TITLE
Update web snippet for better performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,20 @@ several [OpenType features](https://rsms.me/inter/#features), like contextual al
 - To use Inter on a web page, use the official
 [CDN distribution:](https://rsms.me/inter/inter.css)
 
+```html
+<link rel="preconnect" href="https://rsms.me/">
+<link rel="stylesheet" href="https://rsms.me/inter/inter.css">
+```
+
 ```css
-@import url('https://rsms.me/inter/inter.css');
-html { font-family: 'Inter', sans-serif; }
+html {
+  font-family: 'Inter', sans-serif;
+}
+
 @supports (font-variation-settings: normal) {
-  html { font-family: 'Inter var', sans-serif; }
+  html {
+    font-family: 'Inter var', sans-serif;
+  }
 }
 ```
 
@@ -149,4 +158,3 @@ Translating between EM units and pixels:
 - Rasterized at 11px: 1px = 256 units
 - Rasterized at 22px: 1px = 128 units
 - Rasterized at 44px: 1px =  64 units
-

--- a/docs/index.html
+++ b/docs/index.html
@@ -87,10 +87,16 @@ endfor
         the font files. If you're making a web thing, you can use the following CSS.
         <!-- or get it from <a href="https://fonts.google.com/specimen/Inter">Google Fonts</a>. -->
       </p>
-      <pre>@import url('https://rsms.me/inter/inter.css');
-html { font-family: 'Inter', sans-serif; }
+      <pre>&lt;link rel=&quot;preconnect&quot; href=&quot;https://rsms.me/&quot;&gt;
+&lt;link rel=&quot;stylesheet&quot; href=&quot;https://rsms.me/inter/inter.css&quot;&gt;</pre>
+      <pre>html {
+  font-family: 'Inter', sans-serif;
+}
+
 @supports (font-variation-settings: normal) {
-  html { font-family: 'Inter var', sans-serif; }
+  html {
+    font-family: 'Inter var', sans-serif;
+  }
 }</pre>
     </c>
 


### PR DESCRIPTION
When browsers see anything like this in the CSS file:

```css
@import url('https://rsms.me/inter/inter.css');
```

…it takes a pause to:

- Connect to an external domain (DNS, SSL, etc.)
- Start loading the external CSS file

Which is usually delays rendering for a few moments.

Google Font’s snippet is using HTML imports for CSS:

```html
<link rel="preconnect" href="https://fonts.googleapis.com">
<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
<link href="https://fonts.googleapis.com/css2?family=Inter:slnt,wght@-10,400;0,400;0,700&display=swap" rel="stylesheet">
```

While the browser is parsing HTML, the very first thing it does, it also:

- Pre-connects to the external domain
- Start loading the external CSS file

In your case, there’s no need for the second `preconnect` since all the files are on the same domain.

I’d also suggest expanding the snippet a bit for better readability.