### PR TITLE
Downgrade and lock ufo2ft to the known good version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+ufo2ft==2.30.0
 fontmake==3.4.*
 fontbakery==0.8.*
 skia-pathops==0.7.*


### PR DESCRIPTION
Hi! I saw [your Twitter thread](https://twitter.com/rsms/status/1643371448839581698), spent a bit, and found that ufo2ft's recent upgrade broke GitHub actions.

While the package should be fixed in the upstream someday, this change at least makes GitHub Actions green.
