### PR TITLE
[easy] Disable spellcheck on /dynmetrics

### DIFF
--- a/docs/dynmetrics/index.html
+++ b/docs/dynmetrics/index.html
@@ -68,7 +68,7 @@ endfor
       <span class="info"
         title="size, tracking, (ideal tracking) — progress bar shows distance from ideal"
       >15 &nbsp; 0.0 &nbsp; ( 0.0 )</span>
-      <span contenteditable class="content">
+      <span contenteditable spellcheck="false" class="content">
       Such a riot of sea and wind strews the whole extent of beach with whatever has been lost or thrown overboard, or torn out of sunken ships. Many a man has made a good week’s work in a single day by what he has found while walking along the Beach when the surf was down.
       </span>
     </p>


### PR DESCRIPTION
## Summary
The /dynmetrics playground is great — I'm experimenting with some tracking config via the tool, and I noticed that `spellcheck` is disabled everywhere else but not on this page.

## Test Plan
| Before | After |
|--------|-------|
| <img width="1624" alt="Screenshot 2023-05-07 at 10 15 54 AM" src="https://user-images.githubusercontent.com/2268452/236692775-4e62b747-49fe-4ded-a867-353f17cd9095.png"> | <img width="1624" alt="Screenshot 2023-05-07 at 10 16 27 AM" src="https://user-images.githubusercontent.com/2268452/236692784-a86e4ec9-1ecc-4dc8-ae38-38153c51b67f.png"> |