### PR TITLE
website: fix typo

### DIFF
--- a/docs/_data/feature_samples.yml
+++ b/docs/_data/feature_samples.yml
@@ -75,7 +75,7 @@
 
 
 - tag:   sinf
-  title: Scinetific inferiors
+  title: Scientific inferiors
   description: Same as Subscript
   samples:
     - "H›2‹O SF›6‹ H›2‹SO›4‹"


### PR DESCRIPTION
changes "Scinetific" to "Scientific" in the feature samples