### PR TITLE
Google Fonts is no longer outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For web pages, there's an official [CDN distribution](https://rsms.me/inter/inte
 - [Homebrew `font-inter`](https://github.com/Homebrew/homebrew-cask-fonts)
 - [Ubuntu `fonts-inter`](https://packages.ubuntu.com/search?keywords=fonts-inter)
 - [List of Inter available on various Linux distributions…](https://repology.org/project/fonts:inter/versions)
-- [Google Fonts](https://fonts.google.com/specimen/Inter) (outdated version, no italics)
+- [Google Fonts](https://fonts.google.com/specimen/Inter)
 
 **Disclaimer:** Alternate distributions may not always be up-to-date.
 


### PR DESCRIPTION
Google Fonts has had Inter 4.0 with correct Italics for a while (uses latest git commit)