### PR TITLE
Add anchors to Epsilon1, epsilon1, Oopen, oopen

### DIFF
--- a/src/Inter-Italic.glyphspackage/glyphs/E_psilon1.glyph
+++ b/src/Inter-Italic.glyphspackage/glyphs/E_psilon1.glyph
@@ -4,6 +4,10 @@ layers = (
 {
 anchors = (
 {
+name = bottom;
+pos = (539,0);
+},
+{
 name = top;
 pos = (785,1490);
 }
@@ -63,6 +67,10 @@ width = 1264;
 },
 {
 anchors = (
+{
+name = bottom;
+pos = (592,0);
+},
 {
 name = top;
 pos = (836,1490);
@@ -124,6 +132,10 @@ width = 1369;
 {
 anchors = (
 {
+name = bottom;
+pos = (519,0);
+},
+{
 name = top;
 pos = (743,1490);
 }
@@ -183,6 +195,10 @@ width = 1223;
 },
 {
 anchors = (
+{
+name = bottom;
+pos = (526,0);
+},
 {
 name = top;
 pos = (769,1490);
@@ -244,6 +260,10 @@ width = 1225;
 {
 anchors = (
 {
+name = bottom;
+pos = (566,0);
+},
+{
 name = top;
 pos = (807,1490);
 }
@@ -303,6 +323,10 @@ width = 1306;
 },
 {
 anchors = (
+{
+name = bottom;
+pos = (457,0);
+},
 {
 name = top;
 pos = (700,1490);

--- a/src/Inter-Italic.glyphspackage/glyphs/O_open.glyph
+++ b/src/Inter-Italic.glyphspackage/glyphs/O_open.glyph
@@ -4,6 +4,16 @@ kernLeft = C;
 kernRight = D;
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (655,0);
+},
+{
+name = top;
+pos = (902,1490);
+}
+);
 background = {
 shapes = (
 {
@@ -31,6 +41,16 @@ ref = C;
 width = 1495;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (673,0);
+},
+{
+name = top;
+pos = (920,1490);
+}
+);
 layerId = "D0EC06BF-13F9-4C88-A6F5-B8203AF6C77E";
 metricLeft = "=|C";
 metricRight = "=|C";
@@ -45,6 +65,16 @@ ref = C;
 width = 1532;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (647,0);
+},
+{
+name = top;
+pos = (894,1490);
+}
+);
 background = {
 shapes = (
 {
@@ -66,6 +96,16 @@ ref = C;
 width = 1480;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (653,0);
+},
+{
+name = top;
+pos = (899,1490);
+}
+);
 background = {
 shapes = (
 {
@@ -93,6 +133,16 @@ ref = C;
 width = 1479;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (668,0);
+},
+{
+name = top;
+pos = (914,1490);
+}
+);
 layerId = m010;
 metricLeft = "=|C";
 metricRight = "=|C";
@@ -107,6 +157,16 @@ ref = C;
 width = 1509;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (589,0);
+},
+{
+name = top;
+pos = (835,1490);
+}
+);
 background = {
 shapes = (
 {

--- a/src/Inter-Italic.glyphspackage/glyphs/epsilon1.glyph
+++ b/src/Inter-Italic.glyphspackage/glyphs/epsilon1.glyph
@@ -4,6 +4,16 @@ kernLeft = epsilongreek;
 kernRight = epsilongreek;
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (457,0);
+},
+{
+name = top;
+pos = (643,1118);
+}
+);
 layerId = "11F4534A-B963-4AB5-820F-DAF9A20CD933";
 shapes = (
 {
@@ -13,6 +23,16 @@ ref = epsilon;
 width = 1099;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (495,0);
+},
+{
+name = top;
+pos = (681,1118);
+}
+);
 layerId = "D0EC06BF-13F9-4C88-A6F5-B8203AF6C77E";
 shapes = (
 {
@@ -22,6 +42,16 @@ ref = epsilon;
 width = 1176;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (426,0);
+},
+{
+name = top;
+pos = (612,1118);
+}
+);
 layerId = "200BE2C5-40F6-4CF4-AF4F-A33C0CC0964F";
 shapes = (
 {
@@ -31,6 +61,16 @@ ref = epsilon;
 width = 1037;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (399,0);
+},
+{
+name = top;
+pos = (573,1056);
+}
+);
 layerId = m008;
 shapes = (
 {
@@ -40,6 +80,16 @@ ref = epsilon;
 width = 972;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (482,0);
+},
+{
+name = top;
+pos = (656,1056);
+}
+);
 layerId = m010;
 shapes = (
 {
@@ -49,6 +99,16 @@ ref = epsilon;
 width = 1137;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (371,0);
+},
+{
+name = top;
+pos = (545,1056);
+}
+);
 layerId = m012;
 shapes = (
 {

--- a/src/Inter-Italic.glyphspackage/glyphs/oopen.glyph
+++ b/src/Inter-Italic.glyphspackage/glyphs/oopen.glyph
@@ -2,6 +2,16 @@
 glyphname = oopen;
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (462,0);
+},
+{
+name = top;
+pos = (648,1118);
+}
+);
 background = {
 shapes = (
 {
@@ -78,6 +88,16 @@ nodes = (
 width = 1110;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (519,0);
+},
+{
+name = top;
+pos = (705,1118);
+}
+);
 background = {
 shapes = (
 {
@@ -154,6 +174,16 @@ nodes = (
 width = 1224;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (424,0);
+},
+{
+name = top;
+pos = (610,1118);
+}
+);
 background = {
 shapes = (
 {
@@ -230,6 +260,16 @@ nodes = (
 width = 1034;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (434,0);
+},
+{
+name = top;
+pos = (608,1056);
+}
+);
 background = {
 shapes = (
 {
@@ -306,6 +346,16 @@ nodes = (
 width = 1042;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (509,0);
+},
+{
+name = top;
+pos = (683,1056);
+}
+);
 background = {
 shapes = (
 {
@@ -382,6 +432,16 @@ nodes = (
 width = 1192;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (366,0);
+},
+{
+name = top;
+pos = (540,1056);
+}
+);
 background = {
 shapes = (
 {

--- a/src/Inter-Roman.glyphspackage/glyphs/E_psilon1.glyph
+++ b/src/Inter-Roman.glyphspackage/glyphs/E_psilon1.glyph
@@ -2,6 +2,16 @@
 glyphname = Epsilon1;
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (633,0);
+},
+{
+name = top;
+pos = (633,1490);
+}
+);
 layerId = "C698F293-3EC0-4A5A-A3A0-0FDB1F5CF265";
 shapes = (
 {
@@ -13,6 +23,16 @@ scale = (-1,1);
 width = 1265;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (685,0);
+},
+{
+name = top;
+pos = (685,1490);
+}
+);
 layerId = "5C20EF92-B63D-42A8-8878-93C2863E0093";
 shapes = (
 {
@@ -24,6 +44,16 @@ scale = (-1,1);
 width = 1370;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (596,0);
+},
+{
+name = top;
+pos = (596,1490);
+}
+);
 layerId = "B1F27B51-9973-4381-9301-4FE46FE1CA59";
 shapes = (
 {
@@ -35,6 +65,16 @@ scale = (-1,1);
 width = 1192;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (613,0);
+},
+{
+name = top;
+pos = (613,1490);
+}
+);
 layerId = m007;
 shapes = (
 {
@@ -46,6 +86,16 @@ scale = (-1,1);
 width = 1226;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (653,0);
+},
+{
+name = top;
+pos = (653,1490);
+}
+);
 layerId = m009;
 shapes = (
 {
@@ -57,6 +107,16 @@ scale = (-1,1);
 width = 1306;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (544,0);
+},
+{
+name = top;
+pos = (544,1490);
+}
+);
 layerId = m011;
 shapes = (
 {

--- a/src/Inter-Roman.glyphspackage/glyphs/O_open.glyph
+++ b/src/Inter-Roman.glyphspackage/glyphs/O_open.glyph
@@ -4,6 +4,16 @@ kernLeft = C;
 kernRight = D;
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (748,0);
+},
+{
+name = top;
+pos = (748,1490);
+}
+);
 layerId = "C698F293-3EC0-4A5A-A3A0-0FDB1F5CF265";
 shapes = (
 {
@@ -15,6 +25,16 @@ ref = C;
 width = 1496;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (766,0);
+},
+{
+name = top;
+pos = (766,1490);
+}
+);
 layerId = "5C20EF92-B63D-42A8-8878-93C2863E0093";
 shapes = (
 {
@@ -26,6 +46,16 @@ ref = C;
 width = 1531;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (740,0);
+},
+{
+name = top;
+pos = (740,1490);
+}
+);
 layerId = "B1F27B51-9973-4381-9301-4FE46FE1CA59";
 shapes = (
 {
@@ -37,6 +67,16 @@ ref = C;
 width = 1480;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (740,0);
+},
+{
+name = top;
+pos = (740,1490);
+}
+);
 layerId = m007;
 shapes = (
 {
@@ -48,6 +88,16 @@ ref = C;
 width = 1479;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (747,0);
+},
+{
+name = top;
+pos = (747,1490);
+}
+);
 layerId = m009;
 shapes = (
 {
@@ -59,6 +109,16 @@ ref = C;
 width = 1494;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (676,0);
+},
+{
+name = top;
+pos = (676,1490);
+}
+);
 layerId = m011;
 shapes = (
 {

--- a/src/Inter-Roman.glyphspackage/glyphs/epsilon1.glyph
+++ b/src/Inter-Roman.glyphspackage/glyphs/epsilon1.glyph
@@ -4,6 +4,16 @@ kernLeft = epsilongreek;
 kernRight = epsilongreek;
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (550,0);
+},
+{
+name = top;
+pos = (550,1118);
+}
+);
 layerId = "C698F293-3EC0-4A5A-A3A0-0FDB1F5CF265";
 shapes = (
 {
@@ -13,6 +23,16 @@ ref = epsilon;
 width = 1100;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (589,0);
+},
+{
+name = top;
+pos = (589,1118);
+}
+);
 layerId = "5C20EF92-B63D-42A8-8878-93C2863E0093";
 shapes = (
 {
@@ -22,6 +42,16 @@ ref = epsilon;
 width = 1177;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (519,0);
+},
+{
+name = top;
+pos = (519,1118);
+}
+);
 layerId = "B1F27B51-9973-4381-9301-4FE46FE1CA59";
 shapes = (
 {
@@ -31,6 +61,16 @@ ref = epsilon;
 width = 1037;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (486,0);
+},
+{
+name = top;
+pos = (486,1056);
+}
+);
 layerId = m007;
 shapes = (
 {
@@ -40,6 +80,16 @@ ref = epsilon;
 width = 972;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (569,0);
+},
+{
+name = top;
+pos = (569,1056);
+}
+);
 layerId = m009;
 shapes = (
 {
@@ -49,6 +99,16 @@ ref = epsilon;
 width = 1138;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (458,0);
+},
+{
+name = top;
+pos = (458,1056);
+}
+);
 layerId = m011;
 shapes = (
 {

--- a/src/Inter-Roman.glyphspackage/glyphs/oopen.glyph
+++ b/src/Inter-Roman.glyphspackage/glyphs/oopen.glyph
@@ -2,6 +2,16 @@
 glyphname = oopen;
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (556,0);
+},
+{
+name = top;
+pos = (556,1118);
+}
+);
 background = {
 shapes = (
 {
@@ -78,6 +88,16 @@ nodes = (
 width = 1111;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (612,0);
+},
+{
+name = top;
+pos = (612,1118);
+}
+);
 background = {
 shapes = (
 {
@@ -154,6 +174,16 @@ nodes = (
 width = 1224;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (517,0);
+},
+{
+name = top;
+pos = (517,1118);
+}
+);
 background = {
 shapes = (
 {
@@ -230,6 +260,16 @@ nodes = (
 width = 1034;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (521,0);
+},
+{
+name = top;
+pos = (521,1056);
+}
+);
 background = {
 shapes = (
 {
@@ -306,6 +346,16 @@ nodes = (
 width = 1042;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (596,0);
+},
+{
+name = top;
+pos = (596,1056);
+}
+);
 background = {
 shapes = (
 {
@@ -382,6 +432,16 @@ nodes = (
 width = 1192;
 },
 {
+anchors = (
+{
+name = bottom;
+pos = (453,0);
+},
+{
+name = top;
+pos = (453,1056);
+}
+);
 background = {
 shapes = (
 {


### PR DESCRIPTION
Some top and bottom anchors are missing from Epsilon1, epsilon1, Oopen, oopen
<img width="821" alt="Screenshot 2024-10-01 at 14 13 29" src="https://github.com/user-attachments/assets/036bc49d-fd0d-48c9-93e9-029defc3c0c6">

Other anchors should also be added.