### PR TITLE
Google Fonts Inter is not outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For web pages, there's an official [CDN distribution](https://rsms.me/inter/inte
 - [Homebrew `font-inter`](https://github.com/Homebrew/homebrew-cask-fonts)
 - [Ubuntu `fonts-inter`](https://packages.ubuntu.com/search?keywords=fonts-inter)
 - [List of Inter available on various Linux distributions…](https://repology.org/project/fonts:inter/versions)
-- [Google Fonts](https://fonts.google.com/specimen/Inter) (outdated version, no italics)
+- [Google Fonts](https://fonts.google.com/specimen/Inter)
 
 **Disclaimer:** Alternate distributions may not always be up-to-date.
 


### PR DESCRIPTION
It hasn't been outdated for a while, it uses 66647c0bbbe41a850d79d9c76fb13add3378940f and I believe it has correct italics too.