### PR TITLE
Add “Inter Font Extensions” to README’s notable forks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ For web pages, there's an official [CDN distribution](https://rsms.me/inter/inte
 - [Open Runde](https://github.com/lauridskern/open-runde) is a rounded variant of Inter
 - [Interalia](https://github.com/Shavian-info/interalia) extends Inter with Shavian characters
 - [Raveo](https://github.com/jakubfoglar/raveo) is a "warmer version" of Inter
+- [Inter Font Extensions](https://github.com/grab/inter-font-extensions) adds support for Southeast Asian scripts (Khmer, Thai, and Myanmar)
 
 
 ## Supporters & contributors


### PR DESCRIPTION
A simple update to the project’s README to include Grab’s [Inter Font Extensions](https://github.com/grab/inter-font-extensions) fork.